### PR TITLE
fix(storybloq): use path.sep and path.relative in guardPath inside-root check (Windows compat)

### DIFF
--- a/src/core/project-loader.ts
+++ b/src/core/project-loader.ts
@@ -11,7 +11,7 @@ import {
   mkdir,
 } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, resolve, relative, extname, dirname, basename } from "node:path";
+import { join, resolve, relative, extname, dirname, basename, sep, isAbsolute } from "node:path";
 import lockfile from "proper-lockfile";
 import { TicketSchema, type Ticket } from "../models/ticket.js";
 import { IssueSchema, type Issue } from "../models/issue.js";
@@ -1007,7 +1007,8 @@ export async function guardPath(
     resolvedDir = targetDir;
   }
 
-  if (resolvedDir !== resolvedRoot && !resolvedDir.startsWith(resolvedRoot + "/")) {
+  const rel = relative(resolvedRoot, resolvedDir);
+  if (rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel)) {
     throw new ProjectLoaderError(
       "invalid_input",
       `Path ${target} resolves outside project root`,


### PR DESCRIPTION
## Summary

On Windows, `guardPath()` rejects every per-file write under `.story/`. The "inside-project-root" check is hard-coded with the POSIX path separator `"/"`, but `realpath()` on Windows returns paths with backslashes, so the `startsWith()` never matches and every write is rejected as "outside project root".

Repro on Windows 11, Node v22, storybloq 1.4.2:

```shell
  storybloq ticket create --title "demo" --type task --phase p1
  Error [invalid_input]: Path C:...\test-repo.story\tickets\T-001.json resolves outside project root
```

This affects tickets, issues, snapshots, notes, lessons, handovers, channel-inbox messages, and `config set-overrides` / `config set-federation`. Phases and the roadmap escape because they're written directly to `.story/roadmap.json`, where `dirname` equals the wrap-dir and the `resolvedDir === resolvedRoot` early-out passes before the broken `startsWith` is reached. The MCP server has the same bug via the shared bundle.

## Fix

Replaces the broken check with the canonical Node idiom for "is path A inside path B":

```diff
-  if (resolvedDir !== resolvedRoot && !resolvedDir.startsWith(resolvedRoot + "/")) {
+  const rel = relative(resolvedRoot, resolvedDir);
+  if (rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel)) {
```

path.relative() sidesteps the separator question entirely. Rejection covers:

- rel === ".." — escapes exactly one level
- rel.startsWith(".." + sep) — escapes further (the + sep distinguishes the .. segment from a legitimate filename like ..foo)
- isAbsolute(rel) — cases where relative() gives up and returns an absolute path (not relative, Windows cross-drive, etc)

Allowed: "" (target dir equals root) and any relative path without a leading .. segment (target is inside root). Equivalent to a minimal + sep fix on POSIX/Windows, with the added benefit of handling Windows case-insensitivity and mixed-case mount points on network shares.

## Validation

- npm run build clean
- npx vitest run test/core/project-loader.test.ts — 46/46 pass, including the existing guardPath symlink-rejection test
- Manual end-to-end on Windows 11 + Node v22: the original repro now succeeds — 17-ticket creation + dependency wiring + validate + snapshot all complete cleanly