### PR TITLE
fix(autonomous): enforce compactThreshold — rotate session at high context pressure

### DIFF
--- a/src/autonomous/context-pressure.ts
+++ b/src/autonomous/context-pressure.ts
@@ -13,12 +13,17 @@ interface Limits { calls: number; tickets: number; bytes: number; }
  * "medium" = aggressive — compact earlier.
  *
  * Default tier ("high") thresholds:
- * | Level    | Condition                              | Action           |
- * |----------|----------------------------------------|------------------|
- * | low      | <30 calls, <3 tickets, <150KB events   | Continue         |
- * | medium   | 30+ calls OR 3+ tickets OR >150KB      | Evaluate         |
- * | high     | 60+ calls OR 5+ tickets OR >800KB      | (logged only)    |
- * | critical | >90 calls OR 8+ tickets OR >1.5MB      | (logged only)    |
+ * | Level    | Condition                              | Action                    |
+ * |----------|----------------------------------------|---------------------------|
+ * | low      | <30 calls, <3 tickets, <150KB events   | Continue                  |
+ * | medium   | 30+ calls OR 3+ tickets OR >150KB      | Continue                  |
+ * | high     | 60+ calls OR 5+ tickets OR >800KB      | Rotate at next COMPLETE   |
+ * | critical | >90 calls OR 8+ tickets OR >1.5MB      | Rotate at next COMPLETE   |
+ *
+ * The Action column is enforced by pressureMeetsThreshold() below: the COMPLETE
+ * stage rotates the session (routes to HANDOVER instead of PICK_TICKET) once the
+ * evaluated level reaches the configured compactThreshold. Before ISS-034
+ * enforcement the level was computed and displayed but never acted upon.
  */
 const THRESHOLDS: Record<string, { critical: Limits; high: Limits; medium: Limits }> = {
   critical: {
@@ -57,4 +62,39 @@ export function evaluatePressure(state: FullSessionState): PressureLevel {
   if (calls >= t.high.calls || tickets >= t.high.tickets || eventsBytes > t.high.bytes) return "high";
   if (calls >= t.medium.calls || tickets >= t.medium.tickets || eventsBytes > t.medium.bytes) return "medium";
   return "low";
+}
+
+// ---------------------------------------------------------------------------
+// Pressure enforcement (ISS-034)
+// ---------------------------------------------------------------------------
+
+/** Ordinal ranking of pressure levels: low (0) -> critical (3). */
+export const PRESSURE_ORDER: Record<PressureLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+};
+
+/**
+ * Rank of a configured compactThreshold. The valid tier values are the
+ * THRESHOLDS keys ("medium" | "high" | "critical"); anything else -- including
+ * an unset value or the legacy/undocumented "low" -- falls back to "high", so
+ * the comparison stays consistent with evaluatePressure()'s own
+ * `THRESHOLDS[tier] ?? THRESHOLDS["high"]` fallback.
+ */
+const COMPACT_THRESHOLD_RANK: Record<string, number> = {
+  medium: PRESSURE_ORDER.medium,
+  high: PRESSURE_ORDER.high,
+  critical: PRESSURE_ORDER.critical,
+};
+
+/**
+ * Whether the evaluated pressure level has reached (>=) the configured
+ * compactThreshold, i.e. the session should rotate at the next clean boundary.
+ * Pure comparison -- the caller decides what to do when it returns true.
+ */
+export function pressureMeetsThreshold(level: PressureLevel, compactThreshold: string | undefined): boolean {
+  const thresholdRank = COMPACT_THRESHOLD_RANK[compactThreshold ?? ""] ?? PRESSURE_ORDER.high;
+  return PRESSURE_ORDER[level] >= thresholdRank;
 }

--- a/src/autonomous/guide.ts
+++ b/src/autonomous/guide.ts
@@ -2349,12 +2349,25 @@ function guideResult(
     branch: state.git?.branch ?? null,
   };
 
-  // T-178: Inject global anti-cancel reminder for auto mode
+  // T-178: Inject global anti-cancel reminder for auto mode.
+  // ISS-034: make it pressure-aware. Once the evaluated level reaches the
+  // actionable tier, the flat "compaction is automatic" line is misleading — on a
+  // large context window native auto-compact may not fire for a long time, and
+  // Storybloq now rotates the session at the next completed ticket instead. Tell
+  // the model the accurate thing so it neither cancels mid-work nor believes
+  // nothing will change.
   const allReminders = [...(opts.reminders ?? [])];
   if ((state.mode === "auto" || !state.mode) && currentState !== "SESSION_END") {
-    allReminders.push(
-      "NEVER cancel this session due to context size. Compaction is automatic — Storybloq preserves all session state across compactions via hooks.",
-    );
+    const level = state.contextPressure?.level ?? "low";
+    if (level === "high" || level === "critical") {
+      allReminders.push(
+        `Context pressure is ${level}. Storybloq will rotate this session at the next completed ticket to reset context — keep working through the current item; do not cancel or compact manually.`,
+      );
+    } else {
+      allReminders.push(
+        "NEVER cancel this session due to context size. Compaction is automatic — Storybloq preserves all session state across compactions via hooks.",
+      );
+    }
   }
 
   const output: GuideOutput = {

--- a/src/autonomous/stages/complete.ts
+++ b/src/autonomous/stages/complete.ts
@@ -1,6 +1,6 @@
 import type { WorkflowStage, StageResult, StageAdvance, StageContext } from "./types.js";
 import type { GuideReportInput } from "../session-types.js";
-import { evaluatePressure } from "../context-pressure.js";
+import { evaluatePressure, pressureMeetsThreshold } from "../context-pressure.js";
 import { nextTickets } from "../../core/queries.js";
 import { findFirstPostComplete, type NextStageResult } from "./registry.js";
 import { isTargetedMode, getRemainingTargets, buildTargetedCandidatesText, buildTargetedPickInstruction, buildTargetedStuckHandover } from "../target-work.js";
@@ -94,6 +94,24 @@ export class CompleteStage implements WorkflowStage {
       }
     }
 
+    // ISS-034: context-pressure enforcement. COMPLETE is the one clean rotation
+    // boundary -- ticket committed, working tree clean, no partial work. When the
+    // evaluated pressure has reached the configured compactThreshold, rotate the
+    // session here (write a handover and end) instead of picking more work into a
+    // degrading context window. This is the ONLY place compactThreshold changes
+    // behavior; before this it merely labeled contextPressure.level for display.
+    // Rotation never overrides a decision that was already going to HANDOVER, and
+    // only fires when there is more work we would otherwise have continued into.
+    if (nextTarget === "PICK_TICKET" && pressureMeetsThreshold(pressure, ctx.state.config.compactThreshold)) {
+      ctx.appendEvent("pressure_rotation", {
+        level: pressure,
+        compactThreshold: ctx.state.config.compactThreshold,
+        ticketsDone,
+        issuesDone,
+      });
+      return this.buildHandoverResult(ctx, targetedRemaining, ticketsDone, issuesDone, { pressureRotation: true });
+    }
+
     if (nextTarget === "HANDOVER") {
       return this.buildHandoverResult(ctx, targetedRemaining, ticketsDone, issuesDone);
     }
@@ -157,6 +175,7 @@ export class CompleteStage implements WorkflowStage {
     targetedRemaining: string[] | null,
     ticketsDone: number,
     issuesDone: number,
+    opts?: { pressureRotation?: boolean },
   ): StageAdvance {
     // Check postComplete pipeline before going to HANDOVER
     const postComplete = ctx.state.resolvedPostComplete ?? ctx.recipe.postComplete;
@@ -166,9 +185,21 @@ export class CompleteStage implements WorkflowStage {
       return { action: "goto", target: postResult.stage.id };
     }
 
-    const handoverHeader = targetedRemaining !== null
-      ? `# Targeted Session Complete -- All ${ctx.state.targetWork.length} target(s) done`
-      : `# Session Complete -- ${ticketsDone} ticket(s) and ${issuesDone} issue(s) done`;
+    const pressureRotation = opts?.pressureRotation ?? false;
+    const level = ctx.state.contextPressure?.level ?? "high";
+
+    const handoverHeader = pressureRotation
+      ? `# Session Rotating -- context pressure ${level} (${ticketsDone} ticket(s), ${issuesDone} issue(s) done)`
+      : targetedRemaining !== null
+        ? `# Targeted Session Complete -- All ${ctx.state.targetWork.length} target(s) done`
+        : `# Session Complete -- ${ticketsDone} ticket(s) and ${issuesDone} issue(s) done`;
+
+    const rotationNote = pressureRotation
+      ? [
+          "",
+          `Context pressure has reached your configured \`compactThreshold\` (**${ctx.state.config.compactThreshold}**). There is more work available, but rather than continue into a degrading context window the session is rotating now, at a clean boundary -- the ticket is committed and the tree is clean. Write a handover so the next session resumes this work with a fresh context.`,
+        ]
+      : [];
 
     return {
       action: "goto",
@@ -176,6 +207,7 @@ export class CompleteStage implements WorkflowStage {
       result: {
         instruction: [
           handoverHeader,
+          ...rotationNote,
           "",
           "Write a session handover summarizing what was accomplished, decisions made, and what's next.",
           "",

--- a/test/autonomous/stages/complete-pressure-rotation.test.ts
+++ b/test/autonomous/stages/complete-pressure-rotation.test.ts
@@ -1,0 +1,186 @@
+/**
+ * ISS-034: context-pressure enforcement.
+ *
+ * Before this change, evaluatePressure()'s result was written to
+ * contextPressure.level for display but never acted upon: the COMPLETE stage
+ * always continued to PICK_TICKET while work remained, regardless of pressure,
+ * and config.compactThreshold was a no-op. These tests pin the enforced
+ * behavior: at a COMPLETE boundary, when the evaluated level has reached the
+ * configured compactThreshold, the session rotates (routes to HANDOVER) instead
+ * of picking more work.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { StageContext, isStageAdvance } from "../../../src/autonomous/stages/types.js";
+import { CompleteStage } from "../../../src/autonomous/stages/complete.js";
+import { pressureMeetsThreshold } from "../../../src/autonomous/context-pressure.js";
+import type { FullSessionState } from "../../../src/autonomous/session-types.js";
+import type { ResolvedRecipe } from "../../../src/autonomous/stages/types.js";
+
+function makeState(overrides: Partial<FullSessionState> = {}): FullSessionState {
+  const now = new Date().toISOString();
+  return {
+    schemaVersion: 1, sessionId: "00000000-0000-0000-0000-000000000001",
+    recipe: "coding", state: "COMPLETE", revision: 1, status: "active", mode: "auto",
+    reviews: { plan: [], code: [] }, completedTickets: [{ id: "T-001" }],
+    finalizeCheckpoint: null,
+    git: { branch: "main", mergeBase: "abc123", expectedHead: "abc123" },
+    lease: { workspaceId: "test", lastHeartbeat: now, expiresAt: now },
+    contextPressure: { level: "low", guideCallCount: 0, ticketsCompleted: 1, compactionCount: 0, eventsLogBytes: 0 },
+    pendingProjectMutation: null, resumeFromRevision: null, preCompactState: null,
+    compactPending: false, compactPreparedAt: null, resumeBlocked: false,
+    terminationReason: null, waitingForRetry: false, lastGuideCall: now, startedAt: now, guideCallCount: 5,
+    config: { maxTicketsPerSession: 0, compactThreshold: "high", reviewBackends: ["codex", "agent"], handoverInterval: 5 },
+    filedDeferrals: [], pendingDeferrals: [], deferralsUnfiled: false,
+    ...overrides,
+  } as FullSessionState;
+}
+
+function makeRecipe(): ResolvedRecipe {
+  return {
+    id: "coding",
+    pipeline: ["PICK_TICKET", "PLAN", "PLAN_REVIEW", "IMPLEMENT", "CODE_REVIEW", "FINALIZE", "COMPLETE"],
+    postComplete: [], stages: {}, dirtyFileHandling: "block", branchStrategy: "none",
+    defaults: { maxTicketsPerSession: 0, compactThreshold: "high", reviewBackends: ["codex", "agent"] },
+  } as ResolvedRecipe;
+}
+
+/** Read the goto target from a StageAdvance. */
+function gotoTarget(result: unknown): string | undefined {
+  if (result && typeof result === "object" && "action" in result && (result as { action: string }).action === "goto") {
+    return (result as { target?: string }).target;
+  }
+  return undefined;
+}
+
+/** Read the instruction string from a StageAdvance carrying a StageResult. */
+function instructionOf(result: unknown): string {
+  if (result && typeof result === "object" && "result" in result) {
+    const r = (result as { result?: { instruction?: string } }).result;
+    return r?.instruction ?? "";
+  }
+  return "";
+}
+
+describe("pressureMeetsThreshold — ordinal comparison", () => {
+  it("returns true only when level rank >= threshold rank", () => {
+    // default threshold "high"
+    expect(pressureMeetsThreshold("low", "high")).toBe(false);
+    expect(pressureMeetsThreshold("medium", "high")).toBe(false);
+    expect(pressureMeetsThreshold("high", "high")).toBe(true);
+    expect(pressureMeetsThreshold("critical", "high")).toBe(true);
+    // conservative threshold "critical" — only critical fires
+    expect(pressureMeetsThreshold("high", "critical")).toBe(false);
+    expect(pressureMeetsThreshold("critical", "critical")).toBe(true);
+    // aggressive threshold "medium"
+    expect(pressureMeetsThreshold("medium", "medium")).toBe(true);
+    expect(pressureMeetsThreshold("low", "medium")).toBe(false);
+  });
+
+  it("falls back to 'high' for an unknown/legacy threshold value", () => {
+    expect(pressureMeetsThreshold("high", "low")).toBe(true);   // "low" -> "high"
+    expect(pressureMeetsThreshold("medium", "low")).toBe(false);
+    expect(pressureMeetsThreshold("high", undefined)).toBe(true);
+    expect(pressureMeetsThreshold("medium", undefined)).toBe(false);
+  });
+});
+
+describe("CompleteStage — ISS-034 context-pressure rotation", () => {
+  let testRoot: string;
+  let sessionDir: string;
+  const stage = new CompleteStage();
+
+  beforeEach(() => {
+    testRoot = mkdtempSync(join(tmpdir(), "complete-pressure-"));
+    sessionDir = join(testRoot, ".story", "sessions", "test-session");
+    mkdirSync(sessionDir, { recursive: true });
+    mkdirSync(join(testRoot, ".story", "tickets"), { recursive: true });
+    mkdirSync(join(testRoot, ".story", "issues"), { recursive: true });
+    mkdirSync(join(testRoot, ".story", "notes"), { recursive: true });
+    mkdirSync(join(testRoot, ".story", "handovers"), { recursive: true });
+    mkdirSync(join(testRoot, ".story", "lessons"), { recursive: true });
+    writeFileSync(join(testRoot, ".story", "config.json"), JSON.stringify({ version: 1, schemaVersion: 1, project: "test", type: "npm", language: "typescript", features: { tickets: true, issues: true, handovers: true, roadmap: true, reviews: true } }));
+    writeFileSync(join(testRoot, ".story", "roadmap.json"), JSON.stringify({ title: "test", date: "2026-01-01", phases: [], blockers: [] }));
+  });
+
+  afterEach(() => { rmSync(testRoot, { recursive: true, force: true }); });
+
+  /**
+   * Add an open issue so COMPLETE sees remaining work. With an empty roadmap
+   * nextTickets() returns "empty_project", so the routing falls through to the
+   * open-issues check (complete.ts) -- an open issue makes nextTarget PICK_TICKET.
+   */
+  function addOpenWork(): void {
+    writeFileSync(join(testRoot, ".story", "issues", "ISS-001.json"), JSON.stringify({
+      id: "ISS-001", title: "Open bug", status: "open", severity: "medium",
+      components: [], impact: "needs fixing", resolution: null, resolvedDate: null,
+      discoveredDate: "2026-01-01", relatedTickets: [], location: [],
+    }));
+  }
+
+  it("continues to PICK_TICKET at low pressure with work remaining (regression)", async () => {
+    addOpenWork();
+    const state = makeState({
+      contextPressure: { level: "low", guideCallCount: 5, ticketsCompleted: 1, compactionCount: 0, eventsLogBytes: 0 },
+    });
+    const ctx = new StageContext(testRoot, sessionDir, state, makeRecipe());
+    const result = await stage.enter(ctx);
+    expect(isStageAdvance(result)).toBe(true);
+    expect(gotoTarget(result)).toBe("PICK_TICKET");
+  });
+
+  it("rotates to HANDOVER when pressure reaches the default 'high' threshold", async () => {
+    addOpenWork();
+    // default "high" tier: level becomes "high" at 60+ guide calls
+    const state = makeState({
+      contextPressure: { level: "low", guideCallCount: 60, ticketsCompleted: 1, compactionCount: 0, eventsLogBytes: 0 },
+    });
+    const ctx = new StageContext(testRoot, sessionDir, state, makeRecipe());
+    const result = await stage.enter(ctx);
+    expect(gotoTarget(result)).toBe("HANDOVER");
+    const instr = instructionOf(result);
+    expect(instr).toContain("Session Rotating");
+    expect(instr).toContain("compactThreshold");
+  });
+
+  it("does NOT rotate at 'high' pressure when compactThreshold is the conservative 'critical'", async () => {
+    addOpenWork();
+    // critical tier: 90 calls -> level "high" (>=80) but not "critical" (<=120)
+    const state = makeState({
+      contextPressure: { level: "low", guideCallCount: 90, ticketsCompleted: 1, compactionCount: 0, eventsLogBytes: 0 },
+      config: { maxTicketsPerSession: 0, compactThreshold: "critical", reviewBackends: ["codex", "agent"], handoverInterval: 5 },
+    });
+    const ctx = new StageContext(testRoot, sessionDir, state, makeRecipe());
+    const result = await stage.enter(ctx);
+    expect(gotoTarget(result)).toBe("PICK_TICKET");
+  });
+
+  it("rotates once 'critical' pressure is reached under the 'critical' threshold", async () => {
+    addOpenWork();
+    // critical tier: >120 calls -> level "critical"
+    const state = makeState({
+      contextPressure: { level: "low", guideCallCount: 130, ticketsCompleted: 1, compactionCount: 0, eventsLogBytes: 0 },
+      config: { maxTicketsPerSession: 0, compactThreshold: "critical", reviewBackends: ["codex", "agent"], handoverInterval: 5 },
+    });
+    const ctx = new StageContext(testRoot, sessionDir, state, makeRecipe());
+    const result = await stage.enter(ctx);
+    expect(gotoTarget(result)).toBe("HANDOVER");
+    expect(instructionOf(result)).toContain("Session Rotating");
+  });
+
+  it("does not hijack a normal end-of-work HANDOVER (no work left)", async () => {
+    // No open ticket -> nextTarget is HANDOVER regardless of pressure; the
+    // pressure gate must not fire (it only overrides a would-be PICK_TICKET).
+    const state = makeState({
+      contextPressure: { level: "low", guideCallCount: 60, ticketsCompleted: 1, compactionCount: 0, eventsLogBytes: 0 },
+    });
+    const ctx = new StageContext(testRoot, sessionDir, state, makeRecipe());
+    const result = await stage.enter(ctx);
+    expect(gotoTarget(result)).toBe("HANDOVER");
+    const instr = instructionOf(result);
+    expect(instr).toContain("Session Complete");
+    expect(instr).not.toContain("Session Rotating");
+  });
+});


### PR DESCRIPTION
Companion PR to #20, offered humbly and with real gratitude for Storybloq. Happy to rework anything — semantics, defaults, naming — and the open questions below flag the one behavior decision we did not want to make for you.

#### What

Makes `config.compactThreshold` actually do something. Previously `evaluatePressure()` computed `contextPressure.level` and `compactThreshold` selected the tier, but nothing acted on the result — `CompleteStage` always continued to `PICK_TICKET` while work remained, so the config (and the whole pressure pipeline) was advisory-only. See the companion issue for the source-level proof at v1.5.2.

#### Why

On a large context window, Claude Code's native auto-compact — the only thing that actually relieves context today — fires only near the top of the window. A long autonomous session therefore degrades substantially and never rotates, even with `compactThreshold` set. The threshold table in `context-pressure.ts` even annotates its own `high`/`critical` rows `(logged only)`, confirming the enforcement was intended but missing.

#### How

- **`src/autonomous/context-pressure.ts`** — add `PRESSURE_ORDER` (ordinal ranks) and a pure `pressureMeetsThreshold(level, compactThreshold)` helper. The threshold rank uses the same valid tier set as `evaluatePressure` (`medium`/`high`/`critical`, everything else ⇒ `high`), so the comparison and the tier fallback stay consistent. Updated the doc-comment "Action" column (`(logged only)` → `Rotate at next COMPLETE`).
- **`src/autonomous/stages/complete.ts`** — after the existing routing decision, if the next target would be `PICK_TICKET` **and** `pressureMeetsThreshold(pressure, compactThreshold)`, route to `HANDOVER` via the existing `buildHandoverResult(...)` (which still runs the `postComplete` pipeline). A `pressure_rotation` event is appended for observability. `buildHandoverResult` gained an optional `{ pressureRotation }` flag that produces a pressure-aware header + instruction; all other paths are unchanged.
- **`src/autonomous/guide.ts`** — the repeated anti-cancel reminder in `guideResult()` is now pressure-aware: at `high`/`critical` it says the session will rotate at the next completed ticket; otherwise the existing "compaction is automatic" text is unchanged.

The rotation only ever overrides a *would-be* `PICK_TICKET` at a `COMPLETE` boundary (ticket committed, tree clean). It never hijacks a decision already heading to `HANDOVER`, and only fires when there is remaining work the session would otherwise have continued into.

#### How tested

- New: `test/autonomous/stages/complete-pressure-rotation.test.ts` (7 tests) — ordinal comparator + fallback; low pressure still continues to `PICK_TICKET` (regression); `high` pressure rotates under the default `high` threshold; conservative `critical` threshold does **not** rotate at `high` and **does** at `critical`; the pressure gate does not hijack a normal end-of-work `HANDOVER`.
- Full suite: `npx vitest run` — **+7 passing, 0 new failures** vs. base (see "vitest summary" below). Pre-existing failures are environment-dependent (missing built `dist/` for e2e tests, `git checkout main` in a worktree, a missing sibling repo, an inode/fd-semantics lock test) and unrelated to this change.
- `npm run build` (tsup) succeeds (ESM + DTS).

#### Backward compatibility

- No new config keys; no new state fields; no state-machine edges added (`COMPLETE → HANDOVER` already exists).
- Behavior changes **only** for sessions that actually reach the configured `compactThreshold`. Native auto-compact remains the backstop.
- Note for reviewers: because the default `compactThreshold` is `high`, default sessions that reach `high` pressure (≈60 guide calls, or 5 completed items, or >800KB of events, in the default tier) will now rotate at the next completed ticket rather than running until native auto-compact. This is the intended effect of making the documented option work, but it is a default-behavior change — see Open Questions.

#### Open questions

1. **Default-behavior change (the important one).** With the default `compactThreshold: "high"`, sessions now rotate once pressure reaches `high` (≈60 guide calls / 5 completed items / >800KB events, default tier) instead of running to native auto-compact. Is that the rotation point you want as the default? Alternatives, in order of least surprise: (a) keep `high` as shipped (the config was always documented to control this); (b) bump the recipe default to `critical` for minimal disruption (one line in `recipes/coding.json`); (c) gate enforcement behind an explicit opt-in flag. This PR implements (a) and leaves the recipe default untouched.

2. **Proxy vs token telemetry.** Rotation is driven by call/ticket/event-byte proxies because the MCP server has no live token count. Would you accept a follow-up that ingests real token usage (if/when Claude Code exposes it to hooks/MCP), or a dedicated large-window tier, to calibrate rotation to actual window fill? Today's proxies are conservative on 1M windows.

3. **Rotation semantics.** This rotates via a clean `HANDOVER` (session ends at a committed boundary; the next `/story auto` resumes from the handover with fresh context). It does **not** try to trigger Claude Code's native `/compact` mid-session (the MCP server can't invoke slash commands). Is "clean session rotation at a safe boundary" the semantics you want for `compactThreshold`, or do you envision something that hooks the native compaction flow more directly?

4. **Targeted mode.** The gate currently applies uniformly, including targeted (`--target`) sessions — a high-pressure targeted run will rotate before all targets are done (they resume next session via the handover). Acceptable, or should targeted mode be exempt from pressure rotation?

5. **Other "compaction is automatic" sites.** Three sibling sites still carry the unconditional message and were left unchanged (only the repeated per-call reminder in `guideResult` was made pressure-aware): the two session-start instructions `guide.ts:1250` and `:1327` (fire when pressure is low, so accurate there), and the **cancel soft-gate** at `guide.ts:2167` (`# Cancel Rejected — Session Still Active` → "Claude Code handles compaction automatically"), which rejects a context-motivated cancel while telling the model compaction is automatic — the same reassurance that misleads on a large window. Want these softened / made pressure-aware too, for consistency? (Note: the pre-existing `tsc` nit at `guide.ts:2157`, `stuckRetryCount ?? 0 >= 5` typed `{}`, lives in this same cancel handler but is unrelated to pressure/threshold correctness — flagging only so it isn't mistaken for one.)

Thank you for taking the time to review — no expectations on timing or outcome, and we are glad to iterate on any feedback (or close this in favor of your own approach entirely).

> **AI disclosure:** This issue and the accompanying PR were investigated, written, and implemented by Claude Code (Anthropic; model: Claude Fable 5 orchestrating Claude Opus subagents), operating on behalf of a Storybloq user, and were human-reviewed before submission.
