### PR TITLE
feat(skill): add /story triage read-only issue triage workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Inside Claude Code or Codex:
 - **`/story auto T-001 T-002 ISS-013` / `$story auto T-001 T-002 ISS-013`** - autonomous mode scoped to those items. Drives a ticket through plan -> plan review -> implement -> tests -> code review -> commit with handovers at each checkpoint.
 - **`/story review T-001` / `$story review T-001`** - runs the multi-lens review (see [Storybloq/lenses](https://github.com/Storybloq/lenses)) against a ticket's diff.
 - **`/story orchestrate` / `$story orchestrate`** - drives a multi-repo (or large single-repo) backlog when the client exposes exact callable workflow/subagent tools. Codex uses `multi_agent_v1.spawn_agent`, its normalized `multi_agent_v1__spawn_agent` identifier, or an exact `spawn_agent` tool. The Claude Agent View-backed `storybloq dispatch` command is shipped; a product-managed Codex dispatch backend is not.
+- **`/story triage` / `$story triage`** - read-only triage of the open issue backlog: verifies each finding against the pinned current HEAD, flags already-fixed and duplicate issues, groups issues that share one verified root cause, and recommends a prioritized ticket plan. Mutates no issue and no ticket.
 - **`/story bus` / `$story bus`** - polls a task-bound local Bus endpoint so an implementer and an independent reviewer can exchange advisory findings without copy and paste.
 - **`/story handover` / `$story handover`** - writes a session handover capturing decisions, blockers, and next steps.
 

--- a/src/cli/commands/setup-skill.ts
+++ b/src/cli/commands/setup-skill.ts
@@ -962,7 +962,7 @@ async function handleSetupClaude(options: SetupSkillOptions = {}): Promise<void>
   const skillContent = await readFile(join(srcSkillDir, "SKILL.md"), "utf-8");
   await writeFile(join(skillDir, "SKILL.md"), skillContent, "utf-8");
 
-  const supportFiles = ["setup-flow.md", "autonomous-mode.md", "reference.md", "federation-setup.md", "orchestrator-mode.md", "bus-mode.md", "session-guard-fallback.md"];
+  const supportFiles = ["setup-flow.md", "autonomous-mode.md", "reference.md", "federation-setup.md", "orchestrator-mode.md", "triage-mode.md", "bus-mode.md", "session-guard-fallback.md"];
   const writtenFiles = ["SKILL.md"];
   const missingFiles: string[] = [];
   for (const filename of supportFiles) {

--- a/src/core/output-formatter.ts
+++ b/src/core/output-formatter.ts
@@ -2171,6 +2171,16 @@ export function formatReference(
   lines.push("");
   lines.push("`/story` surfaces this option proactively at context load when the client is capable and the actionable backlog is orchestrate-sized, so you do not have to know the command exists; it stays a recommendation, and selecting it still routes through the explicit opt-in.");
   lines.push("");
+  lines.push("## /story triage");
+  lines.push("");
+  lines.push("Read-only triage of the open issue backlog: verifies each finding against the pinned current HEAD (reusing the same source-reference provenance checks as `storybloq validate`), flags already-fixed and duplicate issues, groups issues that share one verified root cause, and produces a prioritized recommendations report.");
+  lines.push("");
+  lines.push("```");
+  lines.push("/story triage                    # triage all open issues, report only");
+  lines.push("```");
+  lines.push("");
+  lines.push("Mutates no issue and no ticket: classifications and recommendations are report vocabulary, and closing or filing stays with the maintainer. The only optional write is saving the finished report as a handover (snapshot first), offered once and performed only on explicit confirmation. The full procedure -- integrity branching, alias correlation, evidence bars, report format -- is in `triage-mode.md`.");
+  lines.push("");
   lines.push("## /story bus");
   lines.push("");
   lines.push("Poll or coordinate through the current task-bound local Bus endpoint. Peer content is advisory; confirmed review findings become canonical issues before an issue notice is sent.");

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -71,6 +71,7 @@ This guard overrides every no-confirmation rule elsewhere. A non-COMPACT live le
 - `/story review-lenses` -> run multi-lens review on current diff (read `review-lenses/review-lenses.md` in the same directory as this skill file; if not found, tell user to run `storybloq setup --client all`). Note: the autonomous guide invokes lenses automatically when `reviewBackends` includes `"lenses"` -- this command is for manual/debug use.
 - `/story federation` -> set up multi-repo orchestrator (read `federation-setup.md` in the same directory as this skill file; if not found, tell user to run `storybloq setup --client all`)
 - `/story orchestrate` -> drive the backlog as orchestrator/pen with tiered background agents (read `orchestrator-mode.md` in the same directory as this skill file; if not found, tell user to run `storybloq setup --client all`)
+- `/story triage` -> read-only triage of the open issue backlog into a prioritized recommendations report (read `triage-mode.md` in the same directory as this skill file; if not found, tell user to run `storybloq setup --client all`)
 - `/story bus` -> poll or coordinate with the current task-bound Storybloq Bus endpoint (read `bus-mode.md` in the same directory as this skill file; if not found, tell user to run `storybloq setup --client all`)
 - `/story help` -> show all capabilities (read `reference.md` in the same directory as this skill file; if not found, tell user to run `storybloq setup --client all`)
 
@@ -514,4 +515,5 @@ Additional skill documentation, loaded on demand:
 - **`design/design.md`** -- Frontend design evaluation and implementation guidance, with platform references in `design/references/`
 - **`federation-setup.md`** -- Federation setup flow for multi-repo orchestrator initialization
 - **`orchestrator-mode.md`** -- Orchestrator mode: tiered multi-agent backlog drive with enrichment pass, session-model review gates, and batched ships
+- **`triage-mode.md`** -- Read-only issue triage: verify findings at HEAD, dedupe, root-cause grouping, prioritized recommendations report
 - **`review-lenses/review-lenses.md`** -- Multi-lens review orchestrator (9 specialized parallel reviewers); prompt bodies and merge semantics live in the @storybloq/lenses package

--- a/src/skill/reference.md
+++ b/src/skill/reference.md
@@ -714,6 +714,16 @@ Requires explicit opt-in via AskUserQuestion before any agents are dispatched, a
 
 `/story` surfaces this option proactively at context load when the client is capable and the actionable backlog is orchestrate-sized, so you do not have to know the command exists; it stays a recommendation, and selecting it still routes through the explicit opt-in.
 
+## /story triage
+
+Read-only triage of the open issue backlog: verifies each finding against the pinned current HEAD (reusing the same source-reference provenance checks as `storybloq validate`), flags already-fixed and duplicate issues, groups issues that share one verified root cause, and produces a prioritized recommendations report.
+
+```
+/story triage                    # triage all open issues, report only
+```
+
+Mutates no issue and no ticket: classifications and recommendations are report vocabulary, and closing or filing stays with the maintainer. The only optional write is saving the finished report as a handover (snapshot first), offered once and performed only on explicit confirmation. The full procedure -- integrity branching, alias correlation, evidence bars, report format -- is in `triage-mode.md`.
+
 ## /story bus
 
 Poll or coordinate through the current task-bound local Bus endpoint. Peer content is advisory; confirmed review findings become canonical issues before an issue notice is sent.

--- a/src/skill/triage-mode.md
+++ b/src/skill/triage-mode.md
@@ -1,0 +1,180 @@
+# Triage Mode
+
+This file is referenced from SKILL.md for `/story triage` (`$story triage` on Codex). It instructs the session to run a **read-only triage pass** over the open issue backlog: verify every finding against the current repository, identify already-fixed and duplicate issues, group issues that share one root cause, and produce a prioritized recommendations report the maintainer can act on.
+
+## The contract: report, never write
+
+This workflow mutates no issue, no ticket, no severity, and creates nothing. The classifications and recommendations defined below are OUTPUT VOCABULARY for the report, never values to write into the ledger. Evidence only -- the maintainer closes, files, and reprioritizes; never this workflow. Do not call any `storybloq_*` create/update/delete tool or any `storybloq ... create/update/delete` CLI command during triage.
+
+Two precise qualifications:
+
+- Ordinary Storybloq reads may recover an incomplete transaction journal under lock. That is the loader's own behavior, not a write this workflow performs.
+- After the report is presented, this workflow may offer ONE optional persistence step: on explicit user confirmation, run `storybloq snapshot` and then `storybloq_handover_create` to save the report as a handover (snapshot first -- the parent skill requires it before a handover). Disclose both writes in the offer. Never any other write.
+
+Epistemics: backlogs rot. An issue's text is a CLAIM made at discovery time; the repository at the pinned HEAD is the source of truth. Verify every claim before classifying it.
+
+## Step 1: Pin the snapshot
+
+1. Record `git rev-parse HEAD` and the current date. Every verified fact in the report is pinned `@ <sha>`.
+2. Run `git status --porcelain`. If the worktree is dirty, either perform manual code inspection through `git show <sha>:<path>` so evidence stays pinned to HEAD, or disclose in the report that verification used the working tree.
+3. If the repository has no HEAD yet (unborn branch), say so in the report and verify against the working tree throughout -- this matches how Storybloq's own source-reference validation falls back.
+
+## Step 2: Gather validate FIRST and branch on its payload
+
+Run `storybloq validate --format json` via Bash. Parse stdout regardless of exit code -- a non-zero exit means findings with error level exist, and warning-only runs exit zero; neither is a command failure.
+
+Every Storybloq JSON response is an envelope holding either a `data` key or an `error` key. Branch on which key is present; on an `error` envelope from ANY gather command, disclose the failed surface in the report and never read `data` from it.
+
+The validate payload has two possible shapes. Discriminate explicitly: a ledger integrity result carries `criticalErrorCount` and `itemErrorCount`; a validation result carries `findings` with `warningCount`.
+
+| Payload | Meaning | What to do |
+|---|---|---|
+| Integrity result, `criticalErrorCount > 0` | `config.json` or `roadmap.json` is invalid; project loading fails, so issue and ticket lists are unavailable | Produce an integrity-only PARTIAL report: name each invalid file from the integrity `findings` (`invalid_json` / `schema_error`), state that no issue classification is possible until the maintainer repairs the ledger, and stop after reporting |
+| Integrity result, item errors only (`criticalErrorCount == 0`) | One or more ticket/issue/note/lesson files are malformed; the rest of the ledger loads | Name each invalid file from the integrity `findings`, then continue: run the lists and triage the loadable records; disclose that source-reference validation, orphan detection, and dedupe-key signals did NOT run; mark the report partial |
+| Validation result | Integrity passed; full findings available | Proceed fully |
+
+## Step 3: Gather the ledgers
+
+Run these via Bash, parsing stdout regardless of exit code (list commands can emit complete data and still exit with a partial status when integrity warnings exist):
+
+1. `storybloq issue list --format json` -- UNFILTERED. Record the capture timestamp. Partition `data` into open / inprogress / resolved. Classify only the open issues; report the in-progress and resolved counts as context. Never rely on a `--status` filter to derive the other counts.
+2. `storybloq ticket list --format json` -- full ticket objects for related-ticket resolution and scope reading.
+3. Optionally `storybloq recommend --format json` -- treat it strictly as a weak comparison signal on ordering (see Step 9); it does not validate classifications or groups.
+
+MCP fallback, only when the CLI is unavailable: `storybloq_issue_list` (unfiltered enumerate) plus `storybloq_issue_get` per issue for detail; `storybloq_ticket_list` plus `storybloq_ticket_get` for each related ticket; `storybloq_validate` with `{"format": "json"}`. The MCP list output is markdown without source references, which is why the per-item get calls are required.
+
+## Step 4: Correlate findings to issues
+
+Validation findings do not share one identifier convention, and display ids can collide. Correlate carefully:
+
+1. Build alias indexes for BOTH issues and tickets, mapping each alias to the SET of records that carry it, over three fields: canonical `id`, `displayId`, and every entry of `previousDisplayIds`. These are multimaps -- duplicate display ids are possible, and Storybloq's own resolver treats an alias as resolvable only when exactly one record matches.
+2. A finding's `entity`, or a `relatedTickets` entry, correlates only on a UNIQUE match in the index. Zero matches or multiple matches: route that finding or ticket reference to NEEDS_INVESTIGATION rather than guessing -- attaching evidence or ticket scope to the wrong record is worse than admitting ambiguity.
+3. Source-reference findings (`source_ref_*` codes) carry the issue's display id; orphan and related-ticket findings carry the canonical issue id. The alias index absorbs the difference.
+4. `duplicate_issue_dedupe_key` findings carry no entity. Do not parse the finding message -- compute dedupe-key groups directly from the issue objects already in hand (group open issues by identical `dedupeKey`).
+5. Files the loader dropped are invisible in `issue list`. Name each one in the report under Needs Investigation, sourced from validate: the schema/parse warnings in the normal branch, or the integrity `findings` in the item-error branch.
+
+## Step 5: Verify each finding against the pinned HEAD
+
+For each open issue, use the correlated `source_ref_*` findings as the starting signal, then apply judgment:
+
+| Signal | Default reading |
+|---|---|
+| `source_ref_changed_at_head` / `source_ref_missing_at_head` | The referenced bytes changed or vanished. That is ALL it proves. Default to re-verify, NOT to already-fixed: read the current code and the file history (`git log --oneline -- <path>`) and decide what actually happened |
+| `source_ref_moved_at_head` | The code moved within the file; the claim is likely intact at the new range. Re-verify at the relocated lines |
+| `source_ref_ambiguous_at_head`, `source_ref_original_unverifiable`, `source_ref_revision_unavailable` | NEEDS_INVESTIGATION unless a manual read settles it |
+| No findings (intact references) | Proves only that those bytes survived. The described problem may still be real, already mitigated elsewhere, or misdiagnosed -- read the referenced code and judge the behavior |
+
+Evidence bar for ALREADY_FIXED: current behavioral evidence (read the code at the pinned HEAD and confirm the described problem cannot occur) PLUS corroborating history (a commit or a related ticket whose scope actually covered this defect). Changed bytes alone never clear this bar.
+
+Issues WITHOUT source references are common, and the hash machinery's silence about them means nothing. Locate the code manually through the issue's `location` entries, `components`, and by searching for the symbols named in `impact`. If the code cannot be located, classify NEEDS_INVESTIGATION -- never VALID.
+
+## Step 6: Classify
+
+Every classified open issue gets exactly one classification:
+
+| Classification | Meaning |
+|---|---|
+| VALID | The described problem is confirmed present at the pinned HEAD |
+| ALREADY_FIXED | The evidence bar in Step 5 is met: behavior verified plus corroborating history |
+| DUPLICATE | Points at the same defect as a specific other open issue. Name the canonical issue; prefer the older or better-evidenced one as canonical |
+| SUPERSEDED | The code or design it describes no longer exists, or a newer issue subsumes it entirely |
+| NEEDS_INVESTIGATION | Cannot be settled with the evidence gathered: unlocatable code, ambiguous alias, dropped file, or unresolved verification |
+| NOT_WORTH_FIXING | Real but the cost exceeds the impact -- say why |
+
+Duplicate detection: a shared `dedupeKey` between two active issues is a high-confidence duplicate CANDIDATE and simultaneously a ledger-integrity problem to report (Storybloq treats it as an error state) -- corroborate the semantic match before classifying DUPLICATE; the key alone is not proof. Beyond keys, compare titles, `impact` prose, overlapping source-reference paths, and `components` -- judgment, not string equality.
+
+## Step 7: Root-cause groups, severity, effort
+
+A root-cause group is a set of VALID issues that one change would fix together. The bar is strict: a VERIFIED shared mechanism -- the same defect demonstrated in each member at the pinned HEAD -- plus ONE bounded change and test plan that plausibly fixes every member. Same file or module, or similar `impact` prose, is NOT sufficient on its own. Prefer recommending ONE ticket per verified group over one ticket per issue.
+
+Severity: reassess against today's codebase -- the recorded severity reflects discovery time. Report it as `recorded -> reassessed` and never edit the issue.
+
+Effort: estimate the FIX (group-level for grouped issues) as XS / S / M / L, matching the orchestrator SIZING convention. This is report vocabulary only; issues and tickets have no effort field.
+
+## Step 8: Map to existing tickets
+
+`relatedTickets` on an issue is an ASSOCIATION, not fix ownership. Before recommending that an issue be folded into an existing ticket:
+
+1. Resolve each related ticket through the ticket alias index (unique match only).
+2. Read the ticket's description and scope. Recommend `FIX_WITH_T-xxx` only when the fix genuinely belongs in that ticket's scope -- an open related ticket is not automatically the vehicle.
+3. A complete related ticket did not necessarily attempt this fix. If the issue still reproduces beside a complete related ticket, say so explicitly; if the complete ticket's scope did cover the defect, that is corroborating history for ALREADY_FIXED.
+
+`orphan_issue` findings enumerate open issues with no related ticket -- the ticket-creation candidates. When validation did not run (item-error branch), compute the same set directly: open issues whose `relatedTickets` is empty.
+
+## Step 9: Consistency recheck, then recommend
+
+Before writing the report:
+
+1. Re-run `git rev-parse HEAD`. If it moved since Step 1, mark the report stale (or restart when the drift is substantial) and state what changed.
+2. Re-run `storybloq issue list --format json` and `storybloq ticket list --format json` and compare the relevant `data` semantically against the Step 3 capture. Ledgers can change without HEAD moving -- another task can write the project's issue or ticket files at any time. On drift, restart or mark the report stale, naming the records that changed.
+
+Then assign each classified issue exactly one recommendation:
+
+| Recommendation | Meaning |
+|---|---|
+| FIX_NOW | Valid, high impact; belongs at the top of the backlog |
+| FIX_SOON | Valid, should be scheduled in the near term |
+| BACKLOG | Valid but can wait |
+| FIX_WITH_T-xxx | Fold into the named existing ticket (scope verified in Step 8) |
+| CLOSE_FIXED | Evidence supports already-fixed; the maintainer closes, never this workflow |
+| CLOSE_DUPLICATE_OF_ISS-xxx | Duplicate of the named canonical issue; the maintainer closes |
+| CLOSE_SUPERSEDED | Superseded; the maintainer closes |
+| INVESTIGATE_FIRST | Needs investigation before any other action |
+| WONT_FIX | Recommend not fixing, with the reasoning |
+
+Urgency and vehicle are separate axes: pair a vehicle (`FIX_WITH_T-xxx`, or a proposed NEW ticket) with an urgency tag when both apply -- for example `FIX_WITH_T-050 (FIX_NOW)` or `NEW ticket (BACKLOG)` -- and when an issue is deliberately split across two tickets, name both vehicles.
+
+Cross-check the suggested implementation order against `storybloq recommend` as a WEAK signal on sequencing only -- it knows severity and phase ordering, not your verified groups. Note disagreements in the report rather than silently overriding either source.
+
+## Step 10: The report
+
+Produce the report inline, in this pinned structure:
+
+```markdown
+## Issue Triage Report
+
+**Scanned:** N open issues @ <sha> (<date>, captured <time>) | In progress: I | Resolved: R
+**Disclosures:** <dirty worktree / partial run / stale ledger / none>
+**Summary verdict:** <one sentence: overall backlog health and the single most important action>
+
+### Recommended Tickets (verified root-cause groups first)
+| # | Proposed ticket | Covers | Severity | Effort | Order rationale |
+|---|-----------------|--------|----------|--------|-----------------|
+
+### Per-Issue Classification
+| ID | Title | Classification | Evidence @ HEAD | Recommendation | Effort | Related |
+|----|-------|----------------|-----------------|----------------|--------|---------|
+
+### Close Candidates
+Evidence only -- the maintainer closes, never this workflow.
+| ID | Recommendation | Evidence |
+|----|----------------|----------|
+
+### Needs Investigation
+<one line each, including loader-dropped files and unresolvable aliases>
+
+### Suggested Implementation Order
+1. <step, with dependency/risk rationale; note any disagreement with storybloq recommend>
+
+### JSON Summary
+{ "loadedOpen": N, "valid": V, "alreadyFixed": A, "duplicates": D, "superseded": S,
+  "needsInvestigation": Q, "notWorthFixing": W, "unclassified": U,
+  "droppedFileCount": F, "recommendedTickets": T,
+  "head": "<sha>", "captureTime": "<iso>",
+  "dirtyWorktree": false, "partialRun": false, "staleLedger": false }
+```
+
+Pinned invariants for the JSON summary: the classification counts plus `unclassified` sum exactly to `loadedOpen` (`valid + alreadyFixed + duplicates + superseded + needsInvestigation + notWorthFixing + unclassified == loadedOpen`). `droppedFileCount` stays separate -- dropped files never loaded, so they are not part of `loadedOpen`.
+
+Additional clearly-labeled sections (for example `### Ledger Notes` for hygiene observations that are neither investigation nor classification) may be inserted after Needs Investigation; never replace, rename, or reorder the pinned sections.
+
+## Edge cases
+
+- **Zero open issues:** produce a short report saying so, plus any integrity findings and context counts. No empty tables.
+- **Very large backlogs:** triage in severity-ordered batches (critical first). Count every open issue you did not reach in `unclassified` and say the report is partial. If correlation quality degrades at scale, tell the user a deterministic triage context command is the planned follow-up.
+- **In-progress issues:** counted in the header, never classified -- someone is already on them.
+- **Integrity-only runs** (critical ledger errors): the report is the integrity section plus repair guidance (`storybloq validate --integrity-only`, `storybloq repair --dry-run`); classification resumes after the maintainer repairs the ledger.
+
+## Saving the report (the one optional write)
+
+After presenting the report, offer once: "Save this triage report as a handover? This writes a snapshot first, then a handover file -- no issue or ticket is touched." Only on explicit confirmation, run `storybloq snapshot`, then call `storybloq_handover_create` with the full report and a descriptive slug such as `issue-triage-<date>`. If the user declines or does not answer, write nothing.

--- a/test/cli/commands/reference.test.ts
+++ b/test/cli/commands/reference.test.ts
@@ -15,6 +15,7 @@ describe("reference command", () => {
     expect(output).toContain("## MCP Tools");
     expect(output).toContain("## Common Workflows");
     expect(output).toContain("## Troubleshooting");
+    expect(output).toContain("## /story triage");
   });
 
   it("handleReference json format produces valid JSON", () => {

--- a/test/cli/commands/setup-skill.test.ts
+++ b/test/cli/commands/setup-skill.test.ts
@@ -970,6 +970,40 @@ describe("setup-skill", () => {
     expect(content).toContain("design/design.md");
   });
 
+  it("triage-mode.md pins the corrected data contracts and the read-only posture", async () => {
+    const content = await readFile(
+      join(PROJECT_ROOT, "src", "skill", "triage-mode.md"), "utf-8",
+    );
+    // Read-only sentinel + the one confirmed write path (snapshot before handover)
+    expect(content).toContain("mutates no issue, no ticket");
+    expect(content).toContain("the maintainer closes, files, and reprioritizes; never this workflow");
+    expect(content).toContain("`storybloq snapshot` and then `storybloq_handover_create`");
+    // Gathering contracts: validate-first branch, envelopes, exit codes, unfiltered list
+    expect(content).toContain("storybloq validate --format json");
+    expect(content).toContain("criticalErrorCount");
+    expect(content).toContain("regardless of exit code");
+    expect(content).toContain("storybloq issue list --format json");
+    expect(content).toContain("UNFILTERED");
+    expect(content).toContain("git status --porcelain");
+    // Correlation: multimap alias indexes, dedupe groups from issue objects
+    expect(content).toContain("previousDisplayIds");
+    expect(content).toContain("SET of records");
+    expect(content).toContain("compute dedupe-key groups directly from the issue objects");
+    // Evidence bars: re-verify default, ticket-scope corroboration, verified grouping
+    expect(content).toContain("Default to re-verify, NOT to already-fixed");
+    expect(content).toContain("FIX_WITH_T-xxx");
+    expect(content).toContain("VERIFIED shared mechanism");
+    // Report vocabulary axes and format extensibility
+    expect(content).toContain("Urgency and vehicle are separate axes");
+    expect(content).toContain("never replace, rename, or reorder the pinned sections");
+    // Consistency recheck + summary invariant
+    expect(content).toContain("Ledgers can change without HEAD moving");
+    expect(content).toContain("unclassified");
+    // Vocabulary spot checks
+    expect(content).toContain("ALREADY_FIXED");
+    expect(content).toContain("NEEDS_INVESTIGATION");
+  });
+
   // -------------------------------------------------------------------------
   // Installer copies all support files
   // -------------------------------------------------------------------------
@@ -983,6 +1017,7 @@ describe("setup-skill", () => {
     expect(tsContent).toContain('"autonomous-mode.md"');
     expect(tsContent).toContain('"reference.md"');
     expect(tsContent).toContain('"orchestrator-mode.md"');
+    expect(tsContent).toContain('"triage-mode.md"');
     expect(tsContent).toContain('"bus-mode.md"');
   });
 


### PR DESCRIPTION
## What this adds

`/story triage` (Claude Code) / `$story triage` (Codex): a read-only workflow that turns an accumulated `ISS-xxx` backlog into a fact-checked, prioritized set of recommendations. It verifies every open issue against the pinned current HEAD, flags already-fixed and duplicate findings, groups issues that share one verified root cause, reassesses severity, estimates effort (orchestrator SIZING vocabulary), maps issues to existing tickets, and recommends implementation order.

It mutates no issue and no ticket. Classifications (VALID / ALREADY_FIXED / DUPLICATE / SUPERSEDED / NEEDS_INVESTIGATION / NOT_WORTH_FIXING) and recommendations (FIX_NOW ... WONT_FIX) are report vocabulary only -- closing and filing stay with the maintainer. The single optional write is saving the finished report as a handover (snapshot first, per the SKILL.md session-lifecycle rule), offered once and performed only on explicit confirmation.

## Design

Skill-only: one new `src/skill/triage-mode.md` routed from SKILL.md, following the `/story orchestrate` precedent (74d0548). Zero new runtime surface -- no CLI command, no MCP tool, no schema fields. The workflow consumes existing JSON commands (`validate`, unfiltered `issue list`, `ticket list`, optionally `recommend`) and reuses `validateIssueSourceRefs` as the single source of provenance truth rather than building a second mechanism.

The prompt pins the data contracts these surfaces actually have:

- `storybloq validate` is gathered FIRST and branched four ways: integrity result with `criticalErrorCount > 0` (integrity-only partial report -- lists cannot load), item errors only (triage the loadable records, disclose suppressed signals), normal ValidationResult, and the `{version, error}` envelope from any surface (disclose, never read `data`).
- Findings are correlated through multimap alias indexes over `id` / `displayId` / `previousDisplayIds` for both issues and tickets; ambiguous aliases route to NEEDS_INVESTIGATION instead of guessing. Dedupe-key groups are computed from issue objects (the finding's entity is null by design).
- `source_ref_changed_at_head` defaults to re-verify, not already-fixed; ALREADY_FIXED requires behavioral evidence plus corroborating history. `relatedTickets` is treated as association, not fix ownership -- ticket scope is read before any FIX_WITH recommendation.
- Stdout is parsed regardless of exit code on every gather command; HEAD and both ledgers are re-checked before the report (ledgers can change without HEAD moving); the JSON summary carries the invariant `sum(classificationCounts) + unclassified == loadedOpen` with `droppedFileCount` separate.

## Files

- `src/skill/triage-mode.md` (new) -- the workflow
- `src/skill/SKILL.md` -- routing row + Support Files bullet
- `src/cli/commands/setup-skill.ts` -- `supportFiles` entry (fresh Claude installs copy from this list)
- `src/core/output-formatter.ts` -- `## /story triage` section in `formatReference`
- `src/skill/reference.md` -- regenerated from the built CLI (byte-identity drift gate passes)
- `test/cli/commands/setup-skill.test.ts`, `test/cli/commands/reference.test.ts` -- supportFiles gate entry plus static prompt assertions pinning each contract above
- `README.md` -- one subcommand bullet

No Codex allowlist change needed: every tool the workflow gathers with is already in `CODEX_READ_ONLY_APPROVAL_TOOLS`, and the two save-path tools are write tools that should keep prompting.

## Testing

- All wiring gates pass: reference drift (byte identity), orphan skill-file gate, SKILL.md reference-integrity gate, supportFiles string-match gate, plus the new content assertions. Full `test/cli/` suite: 56 files, 1164 tests passing. (A number of bus/git-e2e suites fail on my machine identically on a clean checkout -- environment-specific, unrelated to this diff.)
- Real-world smoke run: executed end-to-end on a 55-open-issue project ledger. The guard resolved and routed correctly, all 55 issues were verified at HEAD with file:line evidence, un-re-run measurements were disclosed rather than asserted, the consistency recheck detected no drift, the summary invariant held, and nothing was written. Notably it did not over-find: on a backlog that had been hand-triaged the same morning, it correctly reported no duplicates and nothing stale, while still surfacing genuine ledger-hygiene deltas the manual pass missed.
- Not yet exercised on real data: the defensive branches (critical/item integrity failures, malformed files, duplicate display ids, stale sourceRefs). These are covered by static prompt assertions; a further real-backlog run is planned and I am happy to gate merge on it.

## Notes for the maintainer

- The README asks for an issue before non-trivial changes -- happy to file one to anchor this PR (and to carry a tracking id for the commit message) if you would like that first.
- A pre-scoped V2 exists if large backlogs (~50+ issues) show correlation problems in practice: promote the deterministic join to a read-only `storybloq triage` context command reusing `runReadCommand` / `runMcpReadTool`. Deliberately out of scope here, as is any apply mode.

https://claude.ai/code/session_012A7wUtqwbzXfGVewtbBkuQ